### PR TITLE
Refactoring - Revert to Legacy Chat

### DIFF
--- a/src/main/java/dansplugins/rpsystem/commands/global/GlobalChatCommand.java
+++ b/src/main/java/dansplugins/rpsystem/commands/global/GlobalChatCommand.java
@@ -24,21 +24,6 @@ public class GlobalChatCommand {
             return false;
         }
 
-        if (!medievalRoleplayEngine.configService.getBoolean("legacyChat")) {
-
-            if (args.length != 0) {
-                if (args[0].equalsIgnoreCase("hide")) {
-                    addToPlayersWhoHaveHiddenGlobalChat(player);
-                    return true;
-                }
-                if (args[0].equalsIgnoreCase("show")) {
-                    removeFromPlayersWhoHaveHiddenGlobalChat(player);
-                    return true;
-                }
-            }
-
-        }
-
         // remove player from local chat
         removePlayerFromLocalChat(player);
 
@@ -52,26 +37,6 @@ public class GlobalChatCommand {
         }
         else {
             player.sendMessage(medievalRoleplayEngine.colorChecker.getNegativeAlertColor() + "You're already talking in global chat!");
-        }
-    }
-
-    private void addToPlayersWhoHaveHiddenGlobalChat(Player player) {
-        if (!medievalRoleplayEngine.ephemeralData.getPlayersWhoHaveHiddenGlobalChat().contains(player.getUniqueId())) {
-            medievalRoleplayEngine.ephemeralData.getPlayersWhoHaveHiddenGlobalChat().add(player.getUniqueId());
-            player.sendMessage(medievalRoleplayEngine.colorChecker.getPositiveAlertColor() + "Global chat is now hidden!");
-        }
-        else {
-            player.sendMessage(medievalRoleplayEngine.colorChecker.getNegativeAlertColor() + "Global chat is already hidden!");
-        }
-    }
-
-    private void removeFromPlayersWhoHaveHiddenGlobalChat(Player player) {
-        if (medievalRoleplayEngine.ephemeralData.getPlayersWhoHaveHiddenGlobalChat().contains(player.getUniqueId())) {
-            medievalRoleplayEngine.ephemeralData.getPlayersWhoHaveHiddenGlobalChat().remove(player.getUniqueId());
-            player.sendMessage(medievalRoleplayEngine.colorChecker.getPositiveAlertColor() + "Global chat is now visible!");
-        }
-        else {
-            player.sendMessage(medievalRoleplayEngine.colorChecker.getNegativeAlertColor() + "Global chat is already visible!");
         }
     }
 

--- a/src/main/java/dansplugins/rpsystem/config/ConfigService.java
+++ b/src/main/java/dansplugins/rpsystem/config/ConfigService.java
@@ -74,9 +74,6 @@ public class ConfigService {
         if (!getConfig().isBoolean("debugMode")) {
             getConfig().addDefault("debugMode", false);
         }
-        if (!getConfig().isBoolean("legacyChat")) {
-            getConfig().addDefault("legacyChat", false);
-        }
 
         deleteOldConfigOptionsIfPresent();
 
@@ -111,8 +108,7 @@ public class ConfigService {
             }
             else if (option.equalsIgnoreCase("rightClickToViewCard")
                     || option.equalsIgnoreCase("chatFeaturesEnabled")
-                    || option.equalsIgnoreCase("debugMode")
-                    || option.equalsIgnoreCase("legacyChat")) {
+                    || option.equalsIgnoreCase("debugMode")) {
                 getConfig().set(option, Boolean.parseBoolean(value));
                 player.sendMessage(medievalRoleplayEngine.colorChecker.getColorByName(getString("positiveAlertColor")) + "Boolean set!");
             }
@@ -154,7 +150,6 @@ public class ConfigService {
         getConfig().addDefault("negativeAlertColor", "red");
         getConfig().addDefault("chatFeaturesEnabled", true);
         getConfig().addDefault("debugMode", false);
-        getConfig().addDefault("legacyChat", false);
         getConfig().options().copyDefaults(true);
         medievalRoleplayEngine.saveConfig();
     }
@@ -163,7 +158,6 @@ public class ConfigService {
         player.sendMessage(medievalRoleplayEngine.colorChecker.getColorByName(getString("neutralAlertColor")) + "version: " + getConfig().getString("version")
                 + ", debugMode: " + getConfig().getBoolean("debugMode")
                 + ", chatFeaturesEnabled: " + getConfig().getBoolean("chatFeaturesEnabled")
-                + ", legacyChat: " + getConfig().getBoolean("legacyChat")
                 + ", localChatRadius: " + getConfig().getInt("localChatRadius")
                 + ", whisperChatRadius: " + getConfig().getInt("whisperChatRadius")
                 + ", yellChatRadius: " + getConfig().getInt("yellChatRadius")

--- a/src/main/java/dansplugins/rpsystem/listeners/ChatListener.java
+++ b/src/main/java/dansplugins/rpsystem/listeners/ChatListener.java
@@ -61,39 +61,7 @@ public class ChatListener implements Listener {
             }
 
             event.setCancelled(true);
-            return;
         }
-
-        if (!medievalRoleplayEngine.configService.getBoolean("legacyChat")) {
-
-            if (medievalRoleplayEngine.ephemeralData.getPlayersWhoHaveHiddenGlobalChat().contains(event.getPlayer().getUniqueId())) {
-                event.getPlayer().sendMessage(medievalRoleplayEngine.colorChecker.getNegativeAlertColor() + "You have hidden global chat. Type '/ooc show' to talk in global chat.");
-                event.setCancelled(true);
-                return;
-            }
-
-            // global chat
-            for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-                if (medievalRoleplayEngine.isDebugEnabled()) { System.out.println("Attempting to send global message to " + onlinePlayer.getName()); }
-                if (!medievalRoleplayEngine.ephemeralData.getPlayersWhoHaveHiddenGlobalChat().contains(onlinePlayer.getUniqueId())) {
-                    if (medievalRoleplayEngine.isDebugEnabled()) { System.out.println("Preparing message: '" + event.getMessage() + "'"); }
-
-                    // we are good to send the message
-
-                    // regular format
-                    event.setFormat(ChatColor.WHITE + "" + " <%s> %s");
-
-                    // send message
-                    onlinePlayer.sendMessage(ChatColor.WHITE + "<" + event.getPlayer().getName() + "> " + event.getMessage());
-
-                }
-                else {
-                    if (medievalRoleplayEngine.isDebugEnabled()) { System.out.println("Player has hidden global chat!"); }
-                }
-            }
-            event.setCancelled(true);
-        }
-
     }
 
     private String removeStringContainedBetweenAsterisks(String string) {


### PR DESCRIPTION
The changes in this PR return the plugin to its legacy chat system.

The 'legacyChat' config option has been removed.

closes #285 